### PR TITLE
DFEditor: Add exported variable highlighting and reference navigation support

### DIFF
--- a/frontend/packages/dfeditor/README.md
+++ b/frontend/packages/dfeditor/README.md
@@ -1,0 +1,7 @@
+# @dfnotebook/dfeditor
+
+A CodeMirror extension for Dataflow Notebooks that enhances the editor with automatic highlighting of exported variable references. It supports quick navigation to variable definitions and highlights all references across the notebook.
+
+Keyboard Shortcuts for Navigation: 
+1. Navigate to the previous reference of the selected variable: Alt + Shift + U
+2. Navigate to the next reference of the selected variable: Alt + Shift + D

--- a/frontend/packages/dfeditor/package.json
+++ b/frontend/packages/dfeditor/package.json
@@ -1,0 +1,91 @@
+{
+    "name": "@dfnotebook/dfeditor",
+    "version": "4.2.0-beta.0",
+    "description": "Dataflow Notebook codemirror extension to highlight and navigate to the external references",
+    "homepage": "https://github.com/dataflownb/dfnotebook-extension",
+    "bugs": {
+        "url": "https://github.com/dataflownb/dfnotebook-extension/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dataflownb/dfnotebook-extension.git"
+    },
+    "license": "BSD-3-Clause",
+    "author": {
+        "name": "Dataflow Notebook Development Team",
+        "email": "dataflownb@users.noreply.github.com"
+    },
+    "sideEffects": [
+        "style/*.css",
+        "style/index.js"
+    ],
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "style": "style/index.css",
+    "directories": {
+        "lib": "lib/"
+    },
+    "files": [
+        "lib/*.d.ts",
+        "lib/*.js.map",
+        "lib/*.js",
+        "style/*.css",
+        "style/index.js",
+        "src/**/*.{ts,tsx}"
+    ],
+    "scripts": {
+        "build": "tsc -b",
+        "build:lib": "tsc --sourceMap",
+        "build:lib:prod": "tsc",
+        "build:prod": "jlpm clean && jlpm build:lib:prod",
+        "build:test": "tsc --build tsconfig.test.json",
+        "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+        "docs": "typedoc src",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+        "prepublishOnly": "npm run build",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "stylelint": "jlpm stylelint:check --fix",
+        "stylelint:check": "stylelint --cache \"style/**/*.css\"",
+        "test": "jest",
+        "test:cov": "jest --collect-coverage",
+        "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
+        "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
+        "test:watch": "jest --runInBand --watch",
+        "watch": "run-p watch:src",
+        "watch:src": "tsc -w --sourceMap"
+    },
+    "dependencies": {
+        "@dfnotebook/dfoutputarea": "^4.2.0-beta.0",
+        "@dfnotebook/dfutils": "^4.2.0-beta.0",
+        "@jupyterlab/apputils": "^4.3.7",
+        "@jupyterlab/cells": "^4.2.7",
+        "@jupyterlab/codeeditor": "^4.2.7",
+        "@jupyterlab/codemirror": "^4.2.7",
+        "@jupyterlab/coreutils": "^6.2.7",
+        "@jupyterlab/notebook": "^4.2.7",
+        "@jupyterlab/outputarea": "^4.2.7",
+        "@jupyterlab/services": "^7.2.7",
+        "@lumino/coreutils": "^2.1.2",
+        "@lumino/widgets": "^2.3.2"
+    },
+    "devDependencies": {
+        "@jupyter/ydoc": "^2.0.1",
+        "@jupyterlab/nbformat": "^4.2.7",
+        "@jupyterlab/rendermime": "^4.2.7",
+        "@jupyterlab/testing": "^4.2.7",
+        "@types/jest": "^29.2.0",
+        "@types/react": "^18.0.26",
+        "jest": "^29.2.0",
+        "rimraf": "~5.0.5",
+        "typescript": "~5.1.6"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "styleModule": "style/index.js"
+}

--- a/frontend/packages/dfeditor/src/codeRefNavigator.ts
+++ b/frontend/packages/dfeditor/src/codeRefNavigator.ts
@@ -236,6 +236,7 @@ function navigateToCellByVariable(variable: string, variableScope: string|null, 
                 || (id === refId || tag === refId)){
                 notebook.activeCellIndex = index;
                 notebook.scrollToCell(notebook.widgets[index]);
+                notebook.widgets[index].editor?.focus();
                 break;
               }
             }
@@ -302,6 +303,7 @@ function navigateToCellByVariable(variable: string, variableScope: string|null, 
     state.highlightedRefId = cellid;
     computeDecorations(notebookTracker);
     notebook.activeCellIndex = currentCellIndex;
+    notebook.widgets[currentCellIndex].editor?.focus();
   }
 }
 

--- a/frontend/packages/dfeditor/src/codeRefNavigator.ts
+++ b/frontend/packages/dfeditor/src/codeRefNavigator.ts
@@ -1,0 +1,617 @@
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { Extension, RangeSetBuilder } from '@codemirror/state';
+import { IEditorExtensionRegistry, EditorExtensionRegistry } from '@jupyterlab/codemirror';
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  ViewPlugin,
+  ViewUpdate
+} from '@codemirror/view';
+import { INotebookTracker, Notebook } from '@jupyterlab/notebook';
+import { 
+  caretUpEmptyThinIcon, 
+  caretDownEmptyThinIcon, 
+  closeIcon, 
+  LabIcon
+} from '@jupyterlab/ui-components';
+import { VariableScopeAnalyzer } from './parser';
+import { truncateCellId } from '@dfnotebook/dfutils';
+
+export const NAVIGATE_UP_COMMAND = 'notebook:highlight-navigate-up';
+export const NAVIGATE_DOWN_COMMAND = 'notebook:highlight-navigate-down';
+
+// Defines new styles for this extension
+const baseTheme = EditorView.baseTheme({
+    '.cm-highlightRef span': { 
+      color: '#0a31ff',
+    },
+    '.cm-highlightRef span:hover': {
+      textDecoration: 'underline',
+      textDecorationthickness: '1.5px'
+    },
+    '.cm-highlightRef':{
+      color: '#0a31ff'
+    },
+    '.cm-highlightRef:hover':{
+      textDecoration: 'underline',
+      textDecorationthickness: '1.5px'
+    },
+    '.cm-highlightYellow': {
+      backgroundColor: 'yellow'
+    }
+});
+
+const referenceIdStyle = Decoration.mark({
+  class: 'cm-highlightRef'
+});
+
+const highlightYellowStyle = Decoration.mark({
+  class: 'cm-highlightYellow'
+});
+
+const notebookStates = new Map<string, {
+  highlightedVariable: string | null,
+  highlightedVariableWithTag: string | null,
+  highlightedVariableWithRefID: string | null,
+  highlightedRefId: string | null,
+  cellIdInIteration: string | null,
+  navigationBar: HTMLDivElement | null,
+  variableScopeMap: Map<string, string>,
+  selectionMap: Map<string, string>,
+  computingDecorationCellId: string | null;
+}>();
+
+function getNotebookState(notebook: Notebook) {
+  const notebookId = notebook.id;
+  if (!notebookStates.has(notebookId)) {
+    notebookStates.set(notebookId, {
+      highlightedVariable: null,
+      highlightedVariableWithTag: null,
+      highlightedVariableWithRefID: null,
+      highlightedRefId: null,
+      cellIdInIteration: null,
+      navigationBar: null,
+      computingDecorationCellId: null,
+      variableScopeMap: new Map(),
+      selectionMap: new Map()
+    });
+  }
+  return notebookStates.get(notebookId)!;
+}
+
+function analyzeAndHighlightVariables(cellContent: string, notebook: Notebook): DecorationSet {
+  let builder = new RangeSetBuilder<Decoration>();
+  const state = getNotebookState(notebook);
+  state.variableScopeMap = new Map();
+  if (cellContent === '') {
+    return Decoration.none;;
+  }
+
+  const linker = new VariableScopeAnalyzer();
+  const results = linker.analyzeCode(cellContent);
+  const referenceVariables = nbGetOutputVars(notebook)
+  
+  results.forEach(variable => {
+    if((variable.scope == 'undefined' && referenceVariables.has(variable.name))||(variable.name.includes('$'))){
+      builder.add(variable.from, variable.to, referenceIdStyle);
+      state.variableScopeMap.set(`${variable.from}-${variable.to}`, 'undefined')
+
+      if(state.highlightedVariable){
+        if(variable.name === state.highlightedVariable || variable.name === state.highlightedVariableWithRefID || variable.name === state.highlightedVariableWithTag){
+          builder.add(variable.from, variable.to, highlightYellowStyle);
+        }
+      }
+    }    
+  });
+
+  const rangeSet = builder.finish();
+  if (state.computingDecorationCellId != null){
+    let cursor = rangeSet.iter();
+
+    while (cursor.value) {
+      const { from, to, value } = cursor;
+      console.log(`Range from ${from} to ${to} has decoration: ${value.spec.class}`);
+      if(value.spec.class == 'cm-highlightYellow'){
+        state.selectionMap.set(state.computingDecorationCellId, `${from}-${to}`)
+      }
+      cursor.next();
+    }
+  }
+  
+  return rangeSet;
+}
+
+function handleRightClick(event: MouseEvent, view: EditorView, notebookTracker: INotebookTracker){
+    const notebook = notebookTracker.currentWidget?.content;
+    if (!notebook) return;
+
+    const state = getNotebookState(notebook);
+    let clickedCellIndex = -1;
+    for (let i = 0; i < notebook.widgets.length; i++) {
+        const cell = notebook.widgets[i];
+        if (cell.node.contains(event.target as HTMLElement)) {
+            clickedCellIndex = i;
+            break;
+        }
+    }
+
+    if (clickedCellIndex === -1) return;
+
+    const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+    if (pos != null) {
+      const decorations = analyzeAndHighlightVariables(view.state.doc.toString(), notebook);
+      
+      let variable = '';
+      let variableScope:string|undefined|null = null;
+      decorations.between(pos, pos, (from, to) => {
+        variableScope = state.variableScopeMap.get(`${from}-${to}`);
+        variable = view.state.doc.sliceString(from, to);
+        return false;// Stop after finding the first decoration
+      });
+      
+      if (variable) {
+        event.preventDefault();
+        event.stopPropagation(); // Prevent JupyterLab's context menu from appearing
+        showCustomContextMenu(event, variable, variableScope, notebookTracker, clickedCellIndex);
+      }
+    }
+}
+
+function showCustomContextMenu(event: MouseEvent, variable: string, variableScope:string|null, notebookTracker: INotebookTracker, currentCellIndex: number) {
+  const existingMenu = document.querySelector('.reference-context-menu');
+  if (existingMenu) {
+    existingMenu.remove();
+  }
+
+  const menu = document.createElement('div');
+  menu.className = 'reference-context-menu';
+  menu.style.position = 'fixed';
+  menu.style.left = `${event.clientX}px`;
+  menu.style.top = `${event.clientY}px`;
+  menu.style.backgroundColor = '#fff';
+  menu.style.border = '1px solid #ccc';
+  menu.style.padding = '5px';
+
+  const gotoDefination = createMenuOption('Go to Defination', () => navigateToCellByVariable(variable, variableScope, notebookTracker,currentCellIndex, 'definition'));
+  const showReferences = createMenuOption('Show references', () => navigateToCellByVariable(variable, variableScope, notebookTracker, currentCellIndex,'references'));
+
+  menu.appendChild(gotoDefination);
+  menu.appendChild(showReferences);
+  document.body.appendChild(menu);
+
+  document.addEventListener('click', () => {
+    menu.remove();
+  }, { once: true });
+}
+
+function createMenuOption(text: string, onClick: () => void): HTMLDivElement {
+  const option = document.createElement('div');
+  option.textContent = text;
+  option.style.cursor = 'pointer';
+  option.style.padding = '5px';
+  option.addEventListener('click', () => {
+    onClick();
+    document.querySelector('.reference-context-menu')?.remove();
+  });
+  return option;
+}
+
+function navigateToCellByVariable(variable: string, variableScope: string|null, notebookTracker: INotebookTracker, currentCellIndex: number, menuItem: 'definition' | 'references' | 'next') {
+  const notebook = notebookTracker.currentWidget?.content;
+  if (!notebook) return null;
+
+  const state = getNotebookState(notebook);
+
+  let tagsref = new Map<string, string>();
+  let cells = notebook.model?.cells;
+  if (cells){
+    for (let index = 0; index < cells.length; index++) {
+        let cAny = cells.get(index)
+        if(cAny.type === 'code'){
+          let id = cAny.id.replace(/-/g, '').substring(0, 8);
+          let tag = cAny.getMetadata('dfmetadata').tag
+          if(tag.length > 0){
+              tagsref.set(tag, id)
+          }
+        }
+    }
+  }
+  
+  const [identifer, refId] = variable.split('$');
+
+  if(menuItem === 'definition'){
+    if (variableScope == 'local'){
+      notebook.scrollToCell(notebook.widgets[currentCellIndex]);
+    }
+    else if (variableScope == 'undefined'){
+      let cells = notebook.model?.cells;
+      if (cells){
+          for (let index = 0; index < cells.length; index++) {
+            let cAny = cells.get(index)
+            if(cAny.type === 'code'){
+              let id = cAny.id.replace(/-/g, '').substring(0, 8);
+              let tag = cAny.getMetadata('dfmetadata').tag
+              if((refId === undefined && cAny.getMetadata('dfmetadata').outputVars.includes(identifer))
+                || (id === refId || tag === refId)){
+                notebook.activeCellIndex = index;
+                notebook.scrollToCell(notebook.widgets[index]);
+                break;
+              }
+            }
+          }
+      }
+    }
+    
+  }
+  else if(menuItem === 'references'){
+    createNavigationBar(variable, notebookTracker);
+    let cellid = notebookTracker.currentWidget.content?.widgets[currentCellIndex].model.id.replace(/-/g,'').substring(0,8)
+    state.selectionMap = new Map();
+    state.highlightedVariable = variable;
+    const [identifer, refId] = variable.split('$');
+    
+    //when variable exported only once
+    if(refId === undefined){
+      let cells = notebook.model?.cells;
+      if (cells){
+        for (let index = 0; index < cells.length; index++) {
+          let cAny = cells.get(index)
+          if(cAny.type === 'code'){
+            let id = truncateCellId(cAny.id);
+            let tag = cAny.getMetadata('dfmetadata').tag
+            if((refId === undefined && cAny.getMetadata('dfmetadata').outputVars.includes(identifer))
+              || (id === refId || tag === refId)){
+              state.highlightedVariableWithRefID = variable+'$'+id;
+              state.highlightedVariableWithTag = variable+'$'+tag;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    //when variable exported more than once
+    if(refId != undefined){
+      let cells = notebook.model?.cells;
+      if (cells){
+        let exportedVariableCount = 0;
+        for (let index = 0; index < cells.length; index++) {
+          let cAny = cells.get(index)
+          if(cAny.type === 'code'){
+            let id = truncateCellId(cAny.id);
+            let tag = cAny.getMetadata('dfmetadata').tag
+            if(cAny.getMetadata('dfmetadata').outputVars.includes(identifer) && (id === refId || tag === refId)){
+              state.highlightedVariable = identifer;
+              state.highlightedVariableWithRefID = identifer+'$'+id;
+              state.highlightedVariableWithTag = identifer+'$'+tag;
+              exportedVariableCount += 1;
+            }
+            else if(cAny.getMetadata('dfmetadata').outputVars.includes(identifer)){
+              exportedVariableCount += 1
+            }
+          }
+        }
+        if(exportedVariableCount > 1){
+          state.highlightedVariable = variable;
+          state.highlightedVariableWithRefID = null;
+          state.highlightedVariableWithTag = null;
+        }
+      }
+    }
+    state.highlightedRefId = cellid;
+    computeDecorations(notebookTracker);
+    notebook.activeCellIndex = currentCellIndex;
+  }
+}
+
+function createNavigationBar(variable: string, notebookTracker: INotebookTracker) {
+  const notebook = notebookTracker.currentWidget?.content;
+  if (!notebook) return null;
+
+  const state = getNotebookState(notebook);
+  if (state.navigationBar) {
+    state.navigationBar.remove();
+    state.navigationBar = null;
+  }
+
+  const bar = document.createElement('div');
+  bar.className = 'reference-navigation-bar';
+  bar.style.position = 'absolute';
+  bar.style.top = '0';
+  bar.style.right = '0';
+  bar.style.zIndex = '7';
+  bar.style.backgroundColor = 'var(--jp-toolbar-background)';
+  bar.style.borderBottom = 'var(--jp-border-width) solid var(--jp-toolbar-border-color)';
+  bar.style.borderLeft = 'var(--jp-border-width) solid var(--jp-toolbar-border-color)';
+  bar.style.padding = '2px';
+  bar.style.fontSize = 'var(--jp-ui-font-size1)';
+  bar.style.display = 'flex';
+  bar.style.alignItems = 'center';
+
+  const referenceText = document.createElement('span');
+  referenceText.textContent = 'Reference:';
+  referenceText.style.fontWeight = 'bold';
+  referenceText.style.margin = '0 5px';
+  bar.appendChild(referenceText);
+
+  const textBox = document.createElement('div');
+  textBox.style.minWidth='12em';
+  textBox.style.border = 'var(--jp-border-width) solid var(--jp-border-color0)';
+  textBox.style.display = 'flex';
+  textBox.style.backgroundColor = 'var(--jp-layout-color0)';
+  textBox.style.margin = '2px';
+  textBox.style.padding = '4px 6px';
+  textBox.style.alignItems = 'center';
+  textBox.style.overflow = 'hidden';
+  textBox.style.textOverflow = 'ellipsis';
+  textBox.style.whiteSpace = 'nowrap';
+
+  const variableText = document.createElement('span');
+  variableText.textContent = variable;
+  textBox.appendChild(variableText);
+
+  bar.appendChild(textBox);
+
+  const createButton = (icon: LabIcon, title: string, onClick: () => void) => {
+    const button = document.createElement('button');
+    button.className = 'jp-DocumentSearch-button-wrapper';
+    button.setAttribute('tabindex', '0');
+    button.setAttribute('title', title);
+    button.style.margin = '2px';
+    button.style.padding = '2px';
+    button.style.border = 'var(--jp-border-width) solid transparent';
+    
+    icon.element({
+      container: button,
+      elementPosition: 'center',
+      height: '16px',
+      width: '16px',
+    });
+
+    // Add hover and active styles
+    button.style.boxSizing = 'border-box';
+    button.style.cursor = 'pointer';
+    button.style.transition = 'background-color 0.2s';
+
+    // Event listener to add border on hover
+    button.addEventListener('mouseover', () => {
+      button.style.borderColor = ` var(--jp-border-color2)`;
+    });
+
+    // Event listener to remove the border when not hovered
+    button.addEventListener('mouseout', () => {
+        button.style.borderColor = 'transparent';
+    });
+    
+    button.addEventListener('click', onClick);
+    return button;
+  };
+
+   // Create up button
+   const upButton = createButton(caretUpEmptyThinIcon, 'Previous Match', () => {
+    console.log('Up button clicked');
+    navigateHighlight("up",notebookTracker);
+    });
+  bar.appendChild(upButton);
+
+  // Create down button
+  const downButton = createButton(caretDownEmptyThinIcon, 'Next Match', () => {
+    console.log('Down button clicked');
+    navigateHighlight("down",notebookTracker);
+  });
+  bar.appendChild(downButton);
+
+  // Create close button
+  const closeButton = createButton(closeIcon, 'Close', () => {
+    state.navigationBar?.remove();
+    state.selectionMap = new Map();
+    state.highlightedVariable = null;
+    state.highlightedRefId = null;
+    computeDecorations(notebookTracker);
+  });
+  bar.appendChild(closeButton);
+
+  notebook?.node.appendChild(bar);
+  state.navigationBar = bar;
+}
+
+function navigateHighlight(direction: 'up' | 'down', notebookTracker: INotebookTracker) {
+  const notebook = notebookTracker.currentWidget?.content;
+  if (!notebook) return;
+
+  const state = getNotebookState(notebook);
+  const cells = notebook.widgets;
+  const currentIndex = notebook.activeCellIndex;
+  let nextIndex = currentIndex;
+
+  do {
+    nextIndex = direction === 'up' ? (nextIndex - 1 + cells.length) % cells.length : (nextIndex + 1) % cells.length;
+    const cell = cells[nextIndex];
+    if (cell.model.type === 'code') {
+      let cellId = cell.model.sharedModel.getId().replace(/-/g, '').substring(0, 8);
+      if (state.selectionMap.has(cellId)){
+        notebook.activeCellIndex = nextIndex;
+        notebook.scrollToCell(notebook.widgets[nextIndex]);
+        return;
+      }
+    }
+  } while (nextIndex !== currentIndex);
+}
+
+function computeDecorations(notebookTracker:INotebookTracker) {
+  const notebook = notebookTracker.currentWidget?.content;
+  if (!notebook) return;
+
+  const state = getNotebookState(notebook);
+  if (!state.navigationBar) {
+    return;
+  }
+
+  const cells = notebookTracker.currentWidget?.content.model?.cells;
+  if(cells){
+    for (let index = 0; index < cells.length; index++) {
+      let cAny = notebookTracker.currentWidget.content.widgets[index];
+      if(cAny.model.type === 'code'){
+        state.computingDecorationCellId = cAny.model.id.replace(/-/g, '').substring(0, 8);
+        let editor = (cAny.editor as any).editor;
+        editor.dispatch();
+      }
+    }
+  }
+  state.cellIdInIteration = null;
+  state.computingDecorationCellId = null;
+}
+
+function nbGetOutputVars(notebook: Notebook): Set<string> {
+  const nboutputVars: Map<string, string> = new Map<string, string>();
+  const uniqueVars: Set<string> = new Set<string>();
+  const cells = notebook.model?.cells;
+  if (!cells) return uniqueVars;
+
+  for (let index = 0; index < cells.length; index++) {
+    const cell = cells.get(index);
+    let cellId = cell.id.replace(/-/g, '').substring(0, 8);
+    if (cell.type === 'code') {
+      const dfmetadata = cell.getMetadata('dfmetadata');
+      const tag = dfmetadata.tag;
+      if (dfmetadata && Array.isArray(dfmetadata.outputVars)) {
+        for (const outputVar of dfmetadata.outputVars) {
+          if (nboutputVars.has(outputVar)) {
+            nboutputVars.set(outputVar+'$'+cellId, '1');
+            nboutputVars.set(outputVar+'$'+tag, '1');
+            nboutputVars.set(outputVar, 'MoreThanOne');
+          } else {
+            nboutputVars.set(outputVar, cellId);
+            nboutputVars.set(outputVar+'$'+cellId, '1');
+            nboutputVars.set(outputVar+'$'+tag, '1');
+          }
+        }
+      }
+    }
+  }
+  for (const [key, value] of nboutputVars) {
+    if (value !== 'MoreThanOne') {
+      uniqueVars.add(key);
+    }
+  }
+  return uniqueVars;
+}
+
+const showHighlights = (notebookTracker: INotebookTracker) => ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    view: EditorView;
+    state: ReturnType<typeof getNotebookState>;
+    notebook: Notebook;
+
+    constructor(view: EditorView) {
+      this.view = view;
+      this.notebook = notebookTracker.currentWidget!.content;
+      this.state = getNotebookState(this.notebook);
+      const cellContent = view.state.doc.toString();
+      this.decorations = analyzeAndHighlightVariables(cellContent, this.notebook);
+      view.dom.addEventListener('contextmenu', this.handleContextMenu);
+      console.log("CELL CONSTRUCTOR");
+    }
+
+    update(update: ViewUpdate) {
+      if(globalNotebookTracker.currentWidget?.content){
+        this.state = getNotebookState(globalNotebookTracker.currentWidget?.content);
+      }
+      if (update.docChanged || this.state.computingDecorationCellId) {
+        const cellContent = update.state.doc.toString();
+        this.decorations = analyzeAndHighlightVariables(cellContent, this.notebook);
+      }
+    }
+
+    handleContextMenu = (event: MouseEvent) => {
+      handleRightClick(event, this.view, notebookTracker);
+    }
+  },
+  {
+    decorations: v => v.decorations
+  }
+)
+
+export function highlightVariablesExtension(notebookTracker: INotebookTracker): Extension {
+  return [
+    baseTheme,
+    showHighlights(notebookTracker)
+  ];
+}
+
+let globalNotebookTracker: INotebookTracker;
+export function HighlightReferences(app: JupyterFrontEnd, extensions: IEditorExtensionRegistry, notebookTracker: INotebookTracker) {
+    let isExtensionAdded = false;
+
+    notebookTracker.currentChanged.connect((sender, notebook) => {
+      globalNotebookTracker = notebookTracker;
+      console.log('Current notebook changed, globalNotebookTracker updated');
+    });
+
+    notebookTracker.widgetAdded.connect((sender, notebookPanel) => {
+      globalNotebookTracker = notebookTracker;
+      if (notebookPanel && !isExtensionAdded) {
+        extensions.addExtension(
+          Object.freeze({
+            name: 'jupyterlab-highlight-ref:highlight-variables',
+            factory: () =>
+              EditorExtensionRegistry.createConfigurableExtension(() =>
+                highlightVariablesExtension(notebookTracker)
+              ),
+            schema: {
+              type: 'null',
+              title: 'Highlight Variables',
+              description: 'Highlight dataflow notebook variable references in CodeMirror editors.'
+            }
+          })
+        );
+      }
+      isExtensionAdded = true;
+    });
+
+    app.commands.addCommand(NAVIGATE_UP_COMMAND, {
+      label: 'Navigate to Previous Highlight',
+      execute: () => {
+        navigateHighlight('up', notebookTracker);
+      }
+    });
+  
+    app.commands.addCommand(NAVIGATE_DOWN_COMMAND, {
+      label: 'Navigate to Next Highlight',
+      execute: () => {
+        navigateHighlight('down', notebookTracker);
+      }
+    });
+
+    // Add key bindings
+    app.commands.addKeyBinding({
+      command: NAVIGATE_UP_COMMAND,
+      keys: ['Alt Shift U'],
+      selector: '.jp-Cell'
+    });
+  
+    app.commands.addKeyBinding({
+      command: NAVIGATE_DOWN_COMMAND,
+      keys: ['Alt Shift D'],
+      selector: '.jp-Cell'
+    });
+};
+
+export function DfEditorContextMenu(event: MouseEvent, variable: string, variableScope:string|null){
+  let cellId = globalNotebookTracker.activeCell?.model.sharedModel.getId();
+  let cells = globalNotebookTracker.currentWidget?.content.model?.cells;
+  let activeCellIndex = -1;
+  if(cellId && cells){
+    for(let i=0;i< cells?.length;i++){
+      if(cells.get(i).sharedModel.getId() === cellId){
+        activeCellIndex = i;
+        break
+      }
+    }
+    if(activeCellIndex != -1){
+      showCustomContextMenu(event, variable, variableScope, globalNotebookTracker, activeCellIndex)
+    }
+  }
+}

--- a/frontend/packages/dfeditor/src/index.ts
+++ b/frontend/packages/dfeditor/src/index.ts
@@ -1,0 +1,21 @@
+import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import { IEditorExtensionRegistry } from '@jupyterlab/codemirror';
+import { ICommandPalette } from '@jupyterlab/apputils';
+import { HighlightReferences, DfEditorContextMenu } from './codeRefNavigator';
+
+export { DfEditorContextMenu };
+export const dfeditorPlugin: JupyterFrontEndPlugin<void> = {
+  id: 'jupyterlab-highlight-ref:plugin',
+  description: 'A minimal JupyterLab extension adding a CodeMirror extension.',
+  autoStart: true,
+  requires: [IEditorExtensionRegistry, INotebookTracker, ICommandPalette],
+  activate: (
+    app: JupyterFrontEnd,
+    extensions: IEditorExtensionRegistry,
+    notebookTracker: INotebookTracker,
+    palette: ICommandPalette
+  ) => {
+    HighlightReferences(app, extensions, notebookTracker);
+  }
+};

--- a/frontend/packages/dfeditor/src/parser.ts
+++ b/frontend/packages/dfeditor/src/parser.ts
@@ -1,0 +1,479 @@
+import { syntaxTree } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { python } from "@codemirror/lang-python";
+import { SyntaxNode } from "@lezer/common";
+
+interface VariableInfo {
+  name: string;
+  type: string;
+  scope: 'local' | 'global' | 'parameter' | 'undefined';
+  position: {
+    line: number;
+    column: number;
+  };
+  isDefinition: boolean;
+  from: number,
+  to: number
+}
+
+export class VariableScopeAnalyzer {
+  private scopes: Map<string, Set<string>>[] = [new Map()]; // Global scope is at index 0
+  private variables: VariableInfo[] = [];
+
+  analyzeCode(code: string): VariableInfo[] {
+    const state = EditorState.create({ doc: code, extensions: [python()] });
+    const tree = syntaxTree(state);
+    this.visit(tree.topNode, state);
+    return this.variables;
+  }
+
+  private genericVisit(node: SyntaxNode, state: EditorState) {
+    let child = node.firstChild;
+    while (child) {
+      this.visit(child, state);
+      child = child.nextSibling;
+    }
+  }
+
+  private visit(node: SyntaxNode, state: EditorState) {
+    if (false && node.type.isError) {
+        //check error due to $ sign
+        this.handleErrorNode(node, state);
+    }
+
+    switch (node.type.name) {
+        case "FunctionDefinition":
+        case "AsyncFunctionDefinition":
+            this.visitFunctionDefinition(node, state);
+            break;
+        case "LambdaExpression":
+            this.visitLambdaExpression(node, state);
+            break;
+        case "ClassDefinition":
+            this.visitClassDefinition(node, state);
+            break;
+        case "ListComprehensionExpression":
+        case "SetComprehensionExpression":
+        case "GeneratorExpressionExpression":
+        case "DictionaryComprehensionExpression":
+        case "ComprehensionExpression":
+        case "ArrayComprehensionExpression":
+          this.visitComprehension(node, state);
+          break;
+        case "VariableName":
+            this.visitVariableName(node, state, false);
+            break;
+        case "AssignStatement":
+            this.visitAssignStatement(node, state);
+            break;
+        case "ImportStatement":
+        case "FromImportStatement":
+            this.visitImportStatement(node, state);
+            break;
+        case "ForStatement":
+            this.visitForStatement(node, state);
+            break;
+        default:
+            this.genericVisit(node, state);
+    }
+  }
+
+  private visitComprehension(node: SyntaxNode, state: EditorState) {
+    this.scopes.push(new Map()); // Create a new scope for comprehension
+    // Process the comprehension's variables
+    let child = node.firstChild;
+    let statementFor = false;
+    let varList:string[] = [];
+    const {from, to} = {from: node.from, to: node.to};
+    while (child) {
+        if (child.type.name === "for") {
+            statementFor = true;
+        }
+        else if (child.type.name === 'VariableName')
+        {
+            if(statementFor){
+                const name = state.sliceDoc(child.from, child.to);
+                this.addToCurrentScope(name); // Register in current scope
+                this.addVariableInfo(name, child, state, true, child.from, child.to, 'ComprehensionVariable');
+            }
+            else{
+                const name = state.sliceDoc(child.from, child.to);
+                const {text, endOfVariable} = this.referenceIdentifier(child, state);
+                if(text.includes('$') && endOfVariable){
+                    this.addVariableInfo(text, child, state, false, child.from, endOfVariable, 'ComprehensionVariable');
+                }
+                else{
+                    this.addVariableInfo(name, child, state, false, child.from, child.to, 'ComprehensionVariable');
+                }
+            }
+        }
+        else if(child.type.name === "in"){
+            statementFor = false;
+        }
+        else{
+            this.visitExpression(child.firstChild, state);
+        }
+        child = child.nextSibling;
+    }
+    //this.genericVisit(node, state);
+
+    // Get comprehensive defiend variables
+    for(let i=this.variables.length-1; i>=0; i--){
+        let variable = this.variables[i];
+        if(variable.from > from && variable.to < to && variable.type === 'ComprehensionVariable' && variable.isDefinition == true){
+            varList.push(variable.name);
+        }
+    }
+
+    //update scope of comprehensive variables
+    for(let i=this.variables.length-1; i>=0; i--){
+        let variable = this.variables[i];
+        if(variable.from > from && variable.to < to && varList.includes(variable.name)){
+            this.variables[i].type = 'ComprehensionVariable',
+            this.variables[i].scope = 'local';
+        }
+    }
+
+    this.scopes.pop(); // Remove the comprehension scope after processing
+  }
+
+  private visitImportStatement(node: SyntaxNode, state: EditorState) {
+    let child = node.firstChild;
+    while (child) {
+      if (child.type.name === "VariableName") {
+        const name = state.sliceDoc(child.from, child.to);
+        const {text, endOfVariable} = this.referenceIdentifier(child, state);
+        if(text.includes('$') && endOfVariable){
+            this.addToCurrentScope(text);
+            this.addVariableInfo(text, child, state, true, child.from, endOfVariable, 'ImportVariable');
+        }
+        else{
+            this.addToCurrentScope(name);
+            this.addVariableInfo(name, child, state, true, child.from, child.to, 'ImportVariable');
+        }
+      }
+      child = child.nextSibling;
+    }
+  }
+
+  private visitForStatement(node: SyntaxNode, state: EditorState){
+    let child = node.firstChild;
+    let statementFor = false;
+    
+    while (child){
+        if(child.type.name === 'for'){
+            statementFor = true;
+        }
+        else if(child.type.name === "VariableName"){
+            if(statementFor){
+                const name = state.sliceDoc(child.from, child.to);
+                this.addToCurrentScope(name); // Register in current scope
+                this.addVariableInfo(name, child, state, true, child.from, child.to, 'ComprehensionVariable');
+            }
+            else{
+                const name = state.sliceDoc(child.from, child.to);
+                const {text, endOfVariable} = this.referenceIdentifier(child, state);
+                if(text.includes('$') && endOfVariable){
+                    this.addVariableInfo(text, child, state, false, child.from, endOfVariable, 'Variable');
+                }
+                else{
+                    this.addVariableInfo(name, child, state, false, child.from, child.to, 'Variable');
+                }
+            }
+        }
+        else if(child.type.name === 'in'){
+            statementFor = false;
+        }
+        else if(child.type.name.includes('Expression')){
+            this.visitExpression(child.firstChild, state);
+        }
+        child = child.nextSibling;
+    }
+
+    const body = node.getChild("Body");
+    if (body) {
+      this.genericVisit(body, state);
+    }
+  }
+
+  private visitFunctionDefinition(node: SyntaxNode, state: EditorState) {
+    const nameNode = node.getChild("VariableName");
+    if (nameNode) {
+      const name = state.sliceDoc(nameNode.from, nameNode.to);
+      const {text, endOfVariable} = this.referenceIdentifier(nameNode, state);
+      if(text.includes('$') && endOfVariable){
+        this.addToCurrentScope(text);
+        this.addVariableInfo(text, nameNode, state, true, nameNode.from, endOfVariable, 'MethodName');
+      }
+      else{
+        this.addToCurrentScope(name);
+        this.addVariableInfo(name, nameNode, state, true, nameNode.from, nameNode.to, 'MethodName');
+      }
+    }
+    
+    this.scopes.push(new Map()); // Create a new scope
+    
+    // Handle parameters
+    const paramList = node.getChild("ParamList");
+    if (paramList) {
+      this.handleParameters(paramList, state);
+    }
+
+    const body = node.getChild("Body");
+    if (body) {
+      this.genericVisit(body, state);
+    }
+    this.scopes.pop(); // Remove the scope after processing
+  }
+
+  private visitLambdaExpression(node: SyntaxNode, state: EditorState) {
+    this.scopes.push(new Map()); // Create a new scope for lambda
+    
+    // Handle lambda parameters
+    const paramList = node.getChild("ParamList");
+    if (paramList) {
+      this.handleParameters(paramList, state);
+    }
+
+    const body = node.getChild("Expression") || node.getChild("BinaryExpression");
+    if (body) {
+      this.visit(body, state);
+    }
+
+    this.scopes.pop(); // Remove the lambda scope after processing
+  }
+
+  private handleParameters(paramList: SyntaxNode, state: EditorState) {
+    let param = paramList.firstChild;
+    while (param) {
+      if (param.type.name === "VariableName") {
+        const paramName = state.sliceDoc(param.from, param.to);
+        this.addToCurrentScope(paramName);
+        this.addVariableInfo(paramName, param, state, true, param.from, param.to,'Parameter');
+      }
+      param = param.nextSibling;
+    }
+  }
+
+  private visitClassDefinition(node: SyntaxNode, state: EditorState) {
+    const nameNode = node.getChild("VariableName");
+    if (nameNode) {
+      const name = state.sliceDoc(nameNode.from, nameNode.to);
+      const {text, endOfVariable} = this.referenceIdentifier(nameNode, state);
+      if(text.includes('$') && endOfVariable){
+        this.addToCurrentScope(text);
+        this.addVariableInfo(text, nameNode, state, true, nameNode.from, endOfVariable, 'ClassName');
+      }
+      else{
+        this.addToCurrentScope(name);
+        this.addVariableInfo(name, nameNode, state, true, nameNode.from, nameNode.to, 'ClassName');
+      }
+    }
+    
+    this.scopes.push(new Map()); // Create a new scope for class
+    const body = node.getChild("Body");
+    if (body) {
+      this.genericVisit(body, state);
+    }
+    this.scopes.pop(); // Remove the class scope after processing
+  }
+
+  private visitVariableName(node: SyntaxNode, state: EditorState, isDefinition: boolean) {
+    const name = state.sliceDoc(node.from, node.to);
+    const parent = node.parent;
+
+    // Skip if it's part of a function or class definition
+    if (parent?.type.name === "FunctionDefinition" || parent?.type.name === "ClassDefinition") {
+      return;
+    }
+
+    let recentParsedVariable = this.variables.length > 0 ? this.variables[this.variables.length - 1] : null;
+    if(recentParsedVariable && state.doc.lineAt(node.from).number == recentParsedVariable.position.line && recentParsedVariable.to > node.from){
+        return
+    }
+
+    const {text, endOfVariable} = this.referenceIdentifier(node, state);
+    if(text.includes('$') && endOfVariable){
+        this.addVariableInfo(text, node, state, isDefinition, node.from, endOfVariable, 'Variable');
+    }
+    else{
+        this.addVariableInfo(name, node, state, isDefinition, node.from, node.to, 'Variable');
+    }
+
+  }
+
+  private visitAssignTarget(node: SyntaxNode, state: EditorState) {
+    switch (node.type.name) {
+      case "VariableName":
+        const name = state.sliceDoc(node.from, node.to);
+        this.addToCurrentScope(name);
+        this.visitVariableName(node, state, true);
+        break;
+      case "TupleExpression":
+      case "ArrayExpression":
+      case "ParenthesizedExpression":
+        this.visitTupleOrArrayExpression(node, state);
+        break;
+    }
+  }
+
+  private visitTupleOrArrayExpression(node: SyntaxNode, state: EditorState) {
+    let child = node.firstChild;
+    while (child) {
+      if (child.type.name === "VariableName") {
+        const name = state.sliceDoc(node.from, node.to);
+        this.addToCurrentScope(name);
+        this.visitVariableName(node, state, true);
+      } else if (child.type.name === "TupleExpression" || 
+                 child.type.name === "ArrayExpression" ||
+                 child.type.name === "ParenthesizedExpression") {
+        this.visitTupleOrArrayExpression(child, state);
+      }
+      child = child.nextSibling;
+    }
+  }
+
+  private visitAssignStatement(node: SyntaxNode, state: EditorState) {
+    let targetNode = node.firstChild;
+    let tagetNodeRHS = targetNode ? targetNode.nextSibling : null; 
+    while (targetNode && targetNode.type.name !== "AssignOp") {
+      this.visitAssignTarget(targetNode, state);
+      targetNode = targetNode.nextSibling;
+    }
+
+    // Visit the right side of the assignment
+    if (tagetNodeRHS) {
+        this.visitExpression(tagetNodeRHS, state);
+    }
+  }
+
+  private visitExpression(node: SyntaxNode|null, state: EditorState) {
+    let child = node;
+    while (child) {
+        if (child.type.name === 'VariableName'){
+            const name = state.sliceDoc(child.from, child.to);
+            const {text, endOfVariable} = this.referenceIdentifier(child, state);
+            if(text.includes('$') && endOfVariable){
+                this.addVariableInfo(text, child, state, false, child.from, endOfVariable, 'Variable');
+            }
+            else{
+                this.addVariableInfo(name, child, state, false, child.from, child.to, 'Variable');
+            }
+        }
+        else if(child.type.name == 'LambdaExpression'){
+            this.visitLambdaExpression(child, state);
+        }
+        else if( ["ArrayComprehensionExpression", "ListComprehensionExpression", "SetComprehensionExpression", "GeneratorExpressionExpression", "DictionaryComprehensionExpression", "ComprehensionExpression"].includes(child.type.name)){
+            this.visitComprehension(child, state);
+        }
+        else if(child.type.name.includes('Expression') || child.type.name === 'ArgList'){
+            this.visitExpression(child.firstChild, state);
+        }
+        child = child.nextSibling;
+    }
+  }
+
+  private addToCurrentScope(name: string) {
+    const currentScope = this.scopes[this.scopes.length - 1];
+    if (!currentScope.has(name)) {
+      currentScope.set(name, new Set());
+    }
+    currentScope.get(name)!.add(`${this.scopes.length - 1}`);
+  }
+
+  private determineScope(name: string): 'local' | 'global' | 'parameter' | 'undefined' {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      if (this.scopes[i].has(name)) {
+        return i === 0 ? 'global' : 'local';
+      }
+    }
+    return 'undefined';
+  }
+
+  private referenceIdentifier(node: SyntaxNode, state: EditorState){
+    let endOfVariable = node.to;
+    let currentPos = node.to;
+    while (currentPos < state.doc.length) {
+      const nextChar = state.doc.sliceString(currentPos, currentPos + 1);
+      if (/[\w$]/.test(nextChar) || nextChar === '_') {
+        currentPos++;
+      } else {
+        break;
+      }
+    }
+    endOfVariable = currentPos;
+    const text = state.doc.sliceString(node.from, endOfVariable);
+    
+    if(text.includes('$')){
+        return { text:text, endOfVariable: endOfVariable };
+    }
+    
+    return { text:'', endOfVariable:null };
+  }
+
+  private addVariableInfo(name: string, node: SyntaxNode, state: EditorState, isDefinition: boolean, from:number, to:number, type: string, forcedScope?: 'local' | 'global' | 'parameter' | 'undefined') {
+    const scope = this.determineScope(name);
+    const position = state.doc.lineAt(node.from);
+    this.variables.push({
+      name,
+      type,
+      scope,
+      position: {
+        line: position.number,
+        column: node.from - position.from
+      },
+      isDefinition,
+      from: from,
+      to: to
+    });
+  }
+
+  private handleErrorNode(node: SyntaxNode, state: EditorState) {
+    let startOfVariable = node.from;
+    let endOfVariable = node.to;
+  
+    // First, scan backward from 'node.from' to capture any part of the variable missed due to an error
+    let currentPos = node.from;
+    while (currentPos > 0) {
+        const prevChar = state.doc.sliceString(currentPos - 1, currentPos);
+        // Treat $ and alphanumeric characters as part of the identifier
+        if (/[\w$]/.test(prevChar) || prevChar === '_') {
+            currentPos--;
+        } else {
+            break;
+        }
+    }
+
+    startOfVariable = currentPos; // Adjust start to the first character of the variable
+
+  // Now, scan forward to capture the rest of the variable, including $ and alphanumeric characters
+  currentPos = node.to;
+  while (currentPos < state.doc.length) {
+    const nextChar = state.doc.sliceString(currentPos, currentPos + 1);
+    // Treat $ and alphanumeric characters as part of the identifier
+    if (/[\w$]/.test(nextChar) || nextChar === '_') {
+      currentPos++;
+    } else {
+      break;
+    }
+  }
+
+  endOfVariable = currentPos; // Adjust end to the last character of the variable
+
+  // Extract the full variable name from the adjusted start and end positions
+  const text = state.doc.sliceString(startOfVariable, endOfVariable);
+
+  //check if the variable contains exactly one $ sign
+  const dollarSignCount = (text.match(/\$/g) || []).length;
+
+  // If the variable contains more than one dollar sign, handle the error accordingly
+  if (dollarSignCount > 1) {
+    console.error(`Error: Variable '${text}' contains more than one $ sign.`);
+    // Handle the error (e.g., ignore the variable or log the issue)
+    return null; // Or return some error representation
+  }
+
+  // If there's exactly one dollar sign, return the extracted variable details
+  return { text, startOfVariable, endOfVariable };
+  } 
+}

--- a/frontend/packages/dfeditor/tsconfig.json
+++ b/frontend/packages/dfeditor/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfigbase",
+    "compilerOptions": {
+      "outDir": "lib",
+      "rootDir": "src"
+    },
+    "include": ["src/*"]
+  }

--- a/frontend/packages/dfnotebook-extension/src/index.ts
+++ b/frontend/packages/dfnotebook-extension/src/index.ts
@@ -101,6 +101,7 @@ import { DataflowCodeCell, DataflowInputArea, getNotebookId, notebookCellMap } f
 import { cellExecutor } from './cellexecutor';
 import { CellBarExtension } from '@jupyterlab/cell-toolbar';
 import { Widget } from '@lumino/widgets';
+import { dfeditorPlugin } from '@dfnotebook/dfeditor';
 import tagSvgstr from '../style/tag.svg';
 
 export const tagIcon = new LabIcon({
@@ -820,6 +821,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   MiniMap,
   GraphManagerPlugin,
   ToggleTags,
+  dfeditorPlugin,
   NotebookCellTrackerPlugin
 ];
 export default plugins;

--- a/frontend/packages/dfnotebook-extension/tsconfig.json
+++ b/frontend/packages/dfnotebook-extension/tsconfig.json
@@ -21,6 +21,10 @@
     {
       "path": "../dfgraph",
       "composite": true
+    },
+    {
+      "path": "../dfeditor",
+      "composite": true
     }
   ]
 }

--- a/frontend/packages/dfoutputarea/style/base.css
+++ b/frontend/packages/dfoutputarea/style/base.css
@@ -9,4 +9,10 @@
 
 .jp-OutputArea-promptOverlay {
   --jp-cell-prompt-width: var(--df-cell-prompt-width);
+  z-index: 0;
+}
+
+.dataflow-output-tag {
+  position: relative;
+  z-index: 100;
 }

--- a/frontend/packages/dfoutputarea/tsconfig.json
+++ b/frontend/packages/dfoutputarea/tsconfig.json
@@ -4,5 +4,11 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src/*"]
+  "include": ["src/*"],
+  "references": [
+    {
+      "path": "../dfeditor",
+      "composite": true
+    }
+  ]
 }


### PR DESCRIPTION
### New Feature: Variable Highlighting and Navigation in Dataflow Notebooks

This PR introduces a new CodeMirror extension (**_dataflownb/frontend/packages/dfeditor_**) that enhances the Dataflow Notebook editor with the following capabilities:

### Features

- **Automatic Highlighting**  
  Highlights references to exported variables (e.g., `x$abc123`) based on cell ID or tag.

- **"Go to Definition" Support**  
  Right-click on a variable and quickly jump to the cell where it was originally defined.

- **"Show References" with Navigation Bar**  
  View all references to a variable across the notebook and use the UI (↑ ↓) or keyboard shortcuts to navigate between them.

- **Keyboard Shortcuts**
  - `Alt + Shift + U`: Jump to the **previous** reference
  - `Alt + Shift + D`: Jump to the **next** reference

- **Support both cell tag and Id**
  - Supports matching variables by both Cell ID and Tag
