### PR TITLE
CellExecutor: Add tests for uuid reference, tag reference and dfmetdata

### DIFF
--- a/dfnotebook/kernel/dataflow.py
+++ b/dfnotebook/kernel/dataflow.py
@@ -39,7 +39,7 @@ class DataflowHistoryManager(object):
     def update_code(self, key, code):        
         # print("CALLING UPDATE CODE", key, code)
         # if code is empty, remove the code_cache, remove links
-        if code == '' and key in self.value_cache:
+        if code == '' and key in self.value_cache and key in self.code_cache:
             self.set_stale(key)
             del self.value_cache[key]
             del self.code_cache[key]

--- a/dfnotebook/kernel/ipkernel.py
+++ b/dfnotebook/kernel/ipkernel.py
@@ -422,6 +422,7 @@ class IPythonKernel(ipykernel.ipkernel.IPythonKernel):
             reply_content["status"] = "ok"
 
             if hasattr(res, "nodes"):
+                reply_content["executed_cell_uuid"] = uuid
                 reply_content["nodes"] = res.nodes
                 reply_content["links"] = res.links
                 reply_content["cells"] = res.cells

--- a/dfnotebook/kernel/ipkernel.py
+++ b/dfnotebook/kernel/ipkernel.py
@@ -148,7 +148,8 @@ class IPythonKernel(ipykernel.ipkernel.IPythonKernel):
         self._outer_dfkernel_data = dfkernel_data
         self._identifier_refs = {}
         self._persistent_code = {}
-
+        self._expectedUUID = dfkernel_data.get("expectedUUID")
+        
         res = await self.inner_execute_request(
             code,
             dfkernel_data.get("uuid"),
@@ -422,6 +423,7 @@ class IPythonKernel(ipykernel.ipkernel.IPythonKernel):
             reply_content["status"] = "ok"
 
             if hasattr(res, "nodes"):
+                reply_content["expected_UUID"] = self._expectedUUID
                 reply_content["executed_cell_uuid"] = uuid
                 reply_content["nodes"] = res.nodes
                 reply_content["links"] = res.links

--- a/frontend/packages/dfcells/src/widget.ts
+++ b/frontend/packages/dfcells/src/widget.ts
@@ -309,7 +309,8 @@ export namespace DataflowCodeCell {
         sessionContext,
         metadata,
         dfData,
-        cellIdOutputsMap
+        cellIdOutputsMap,
+        cell.model.id.substr(0, 8)
       );
 
       // cell.outputArea.future assigned synchronously in `execute`
@@ -409,8 +410,8 @@ export namespace DataflowCodeCell {
         GraphManager.updateDepViews(false);
       }
 
-       if (content.update_downstreams) {
-          GraphManager.graphs[sessId].updateDownLinks(content.update_downstreams);
+      if (content.update_downstreams) {
+        GraphManager.graphs[sessId].updateDownLinks(content.update_downstreams);
       }
 
       return msg;

--- a/frontend/packages/dfcells/src/widget.ts
+++ b/frontend/packages/dfcells/src/widget.ts
@@ -270,7 +270,7 @@ export namespace DataflowCodeCell {
   ): Promise<KernelMessage.IExecuteReplyMsg | void> {
     const model = cell.model;
     const code = model.sharedModel.getSource();
-    if (!code.trim() || !sessionContext.session?.kernel) {
+    if (!sessionContext.session?.kernel) {
       model.sharedModel.transact(() => {
         model.clearExecution();
       }, false);

--- a/frontend/packages/dfcells/src/widget.ts
+++ b/frontend/packages/dfcells/src/widget.ts
@@ -21,7 +21,6 @@ import { IChangedArgs } from '@jupyterlab/coreutils';
 import { ISessionContext } from '@jupyterlab/apputils';
 import { JSONObject } from '@lumino/coreutils';
 import { Panel } from '@lumino/widgets';
-import { NotebookPanel } from '@jupyterlab/notebook';
 
 // FIXME need to add this back when dfgraph is working
 import { Manager as GraphManager } from '@dfnotebook/dfgraph';
@@ -34,8 +33,6 @@ const CELL_INPUT_AREA_CLASS = 'jp-Cell-inputArea';
  * The CSS class added to the cell output area.
  */
 const CELL_OUTPUT_AREA_CLASS = 'jp-Cell-outputArea';
-
-export const notebookCellMap = new Map<string, Map<string, string>>();
 
 function setInputArea<T extends ICellModel = ICellModel>(cell: Cell) {
   // FIXME may be able to get panel via (this.layout as PanelLayout).widgets?
@@ -212,7 +209,6 @@ export class DataflowCodeCell extends CodeCell {
     super.initializeState();
     this.setPromptToId();
     setDFMetadata(this);
-    this.model.contentChanged.connect(this._onContentChanged, this);
     return this;
   }
 
@@ -226,35 +222,6 @@ export class DataflowCodeCell extends CodeCell {
         break;
     }
   }
-
-  private _onContentChanged(): void {
-    let notebookpanelId = getNotebookId(this)
-
-    if(notebookpanelId){
-      const currentCode = this.model.sharedModel.getSource().trim();
-      const cId = truncateCellId(this.model.sharedModel.getId());
-      const executedCode = notebookCellMap.get(notebookpanelId)?.get(cId)?.trim();
-      if (executedCode != ''){
-        if(executedCode === currentCode){
-          this.node.classList.add('df-cell-not-dirty');
-        }
-        else{
-          this.node.classList.remove('df-cell-not-dirty');
-        }
-      }
-    }
-  }
-}
-
-export function getNotebookId(cell: DataflowCodeCell): string|undefined {
-  let parent = cell.parent;
-    while (parent) {
-      if (parent instanceof NotebookPanel) {
-        return parent.id;
-      }
-      parent = parent.parent;
-    }
-  return undefined;
 }
 
 export namespace DataflowCodeCell {

--- a/frontend/packages/dfcells/style/base.css
+++ b/frontend/packages/dfcells/style/base.css
@@ -14,19 +14,3 @@
 .jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-prompt {
   --jp-cell-prompt-width: var(--df-cell-prompt-width);
 }
-
-.jp-Notebook .jp-Cell.jp-mod-active.jp-mod-dirty.df-cell-not-dirty .jp-Collapser{
-  background: var(--jp-brand-color1);
-}
-
-.jp-Notebook .jp-Cell.jp-mod-dirty.df-cell-not-dirty .jp-InputPrompt {
-  color: var(--jp-cell-inprompt-font-color)
-}
-
-.jp-Notebook .jp-Cell:not(.jp-mod-active).jp-mod-dirty.df-cell-not-dirty .jp-InputPrompt {
-  color: var(--jp-cell-prompt-not-active-font-color);
-}
-
-.jp-Notebook .jp-Cell.jp-mod-dirty.df-cell-not-dirty .jp-InputPrompt::before {
-  content: none;
-}

--- a/frontend/packages/dfcells/test/widget.spec.ts
+++ b/frontend/packages/dfcells/test/widget.spec.ts
@@ -944,7 +944,7 @@ describe('cells/widget', () => {
           placeholder: false
         });
         widget.initializeState();
-        let uuid = String(widget.model.executionCount);
+        let uuid = truncateCellId(widget.model.id);
         let mockdata = {'uuid':uuid,'code_dict':{uuid:''}};
         let mockmap = {uuid:widget.model};
         await expect(
@@ -962,7 +962,7 @@ describe('cells/widget', () => {
         widget.initializeState();
         widget.model.sharedModel.setSource('foo = 3');
 
-        let uuid = String(widget.model.id);
+        let uuid = truncateCellId(widget.model.id);
         let mockdata = {'uuid':uuid,'code_dict':{uuid:''}};
         let mockmap = {uuid:widget.model};
         const originalexecutionCount = widget.promptNode!.textContent;
@@ -988,7 +988,7 @@ describe('cells/widget', () => {
           contentFactory,
           placeholder: false
         });
-        let uuid = String(widget.model.executionCount);
+        let uuid = truncateCellId(widget.model.id);
         let mockdata = {'uuid':uuid,'code_dict':{uuid:''}};
         let mockmap = {uuid:widget.model};
         await CodeCell.execute(widget, sessionContext,{},mockdata,mockmap);
@@ -1002,7 +1002,7 @@ describe('cells/widget', () => {
           contentFactory,
           placeholder: false
         });
-        let uuid = String(widget.model.executionCount);
+        let uuid = truncateCellId(widget.model.id);
         let mockdata = {'uuid':uuid,'code_dict':{uuid:''}};
         let mockmap = {uuid:widget.model};
         await CodeCell.execute(widget, sessionContext, { recordTiming: true },mockdata,mockmap);
@@ -1023,7 +1023,7 @@ describe('cells/widget', () => {
         widget.initializeState();
         widget.model.sharedModel.setSource('foo = 3');
         
-        let uuid = String(widget.model.id);
+        let uuid = truncateCellId(widget.model.id);
         let mockdata = {'uuid':uuid,'code_dict':{uuid:''}};
         let mockmap = {uuid:widget.model};
         const future1 = CodeCell.execute(widget, sessionContext,{},mockdata,mockmap);

--- a/frontend/packages/dfgraph/src/minimap.ts
+++ b/frontend/packages/dfgraph/src/minimap.ts
@@ -169,7 +169,7 @@ export class Minimap {
     let that = this;
     let ups: any = [];
     let downs: any = [];
-    if (!node.classed('active_node')) {
+    if (!node.empty() && !node.classed('active_node')) {
       this.reset();
       node.classed('active_node', true);
       parent.classed('active', true);
@@ -779,7 +779,8 @@ export class Minimap {
 
   /** @method clear graph */
   clearMinimap = function () {
-    $('#minisvg g').empty();
+    d3.select('#minisvg').selectAll('*').remove();
+    this.svg = null
   };
 
   /** @method updates the list of output tags on the graph */
@@ -795,6 +796,10 @@ export class Minimap {
   /** @method starts minimap creation, this is the process that's ran every time **/
   startMinimapCreation = function () {
     if (this.updateCells() && this.updateOutputTags() && this.updateEdges()) {
+      if (!this.svg || d3.select('#minisvg').empty()) {
+        this.svg = d3.select('#minisvg').append('g');
+        this.svg.attr('transform', 'translate(0,0)');
+      }
       let that = this;
       that.createMinimap();
     }

--- a/frontend/packages/dfnotebook-extension/src/index.ts
+++ b/frontend/packages/dfnotebook-extension/src/index.ts
@@ -441,25 +441,26 @@ const GraphManagerPlugin: JupyterFrontEndPlugin<void> = {
                     GraphManager.updateOrder(cellOrder);
                 }
                 console.log(sessId);
-            });
 
-            (nbPanel.content as any).model._cells.changed.connect(() =>{
-                GraphManager.updateOrder((nbPanel.content as any).model.cells.model.cells.map((cell:any) => cell.id));
-            });
-            nbPanel.content.activeCellChanged.connect(() =>{
-                let prevActive = GraphManager.getActive();
-                if(typeof prevActive == 'object' && prevActive.id != undefined ){
-                    let uuid = truncateCellId(prevActive.id);
-                    if(prevActive.sharedModel.source != GraphManager.getText(uuid)){
-                        GraphManager.markStale(uuid);
-                    }
-                    else if(GraphManager.getStale(uuid) == 'Stale'){
-                        GraphManager.revertStale(uuid);
-                    }
-                }
-                //Have to get this off the model the same way that actions.tsx does
-                let activeId = truncateCellId(nbPanel.content.activeCell?.model?.id.replace(/-/g, '') || '');
-                GraphManager.updateActive(activeId,nbPanel.content.activeCell?.model);
+                (nbPanel.content as any).model._cells.changed.connect(() =>{
+                  GraphManager.updateOrder((nbPanel.content as any).model.cells.model.cells.map((cell:any) => cell.id));
+                });
+                
+                nbPanel.content.activeCellChanged.connect(() =>{
+                  let prevActive = GraphManager.getActive();
+                  if(typeof prevActive == 'object' && prevActive.id != undefined ){
+                      let uuid = truncateCellId(prevActive.id);
+                      if(prevActive.sharedModel.source != GraphManager.getText(uuid)){
+                          GraphManager.markStale(uuid);
+                      }
+                      else if(GraphManager.getStale(uuid) == 'Stale'){
+                          GraphManager.revertStale(uuid);
+                      }
+                  }
+                  //Have to get this off the model the same way that actions.tsx does
+                  let activeId = truncateCellId(nbPanel.content.activeCell?.model?.id.replace(/-/g, '') || '');
+                  GraphManager.updateActive(activeId,nbPanel.content.activeCell?.model);
+                });
             });
       });
 

--- a/frontend/packages/dfnotebook/src/cellexecutor.ts
+++ b/frontend/packages/dfnotebook/src/cellexecutor.ts
@@ -179,13 +179,22 @@ import { truncateCellId } from '@dfnotebook/dfutils';
 
   async function dfCommPostData(notebookId: string|undefined, notebook: DataflowNotebookModel, sessionContext: ISessionContext): Promise<void> {
     const dfData = getCellsMetadata(notebook, '');
+    const cellMap = notebookId ? notebookCellMap.get(notebookId) : undefined;
+
     if (!notebook.getMetadata('enable_tags')) {
       dfData.dfMetadata.input_tags = {};
     }
+
     try {
-      const response = await dfCommGetData(sessionContext, {'dfMetadata': dfData.dfMetadata});
+      const executedCode: { [key: string]: string } = {};
+         cellMap?.forEach((value, key) => {
+            executedCode[key] = value;
+      });
+      dfData.dfMetadata.executed_code = executedCode;
+
+      const response = await dfCommGetData(sessionContext, {'dfMetadata': dfData.dfMetadata, 'updateExecutedCode': true});
       if (response?.code_dict && Object.keys(response.code_dict).length > 0) {
-        await updateNotebookCells(notebook, notebookId, response.code_dict);
+        await updateNotebookCells(notebook, notebookId, response);
       }
     } catch (error) {
       console.error('Error during kernel communication:', error);
@@ -208,26 +217,23 @@ import { truncateCellId } from '@dfnotebook/dfutils';
     });
   }
 
-  async function updateNotebookCells(notebook: DataflowNotebookModel, notebookId:string|undefined, codeDict: { [key: string]: any }) {
+  async function updateNotebookCells(notebook: DataflowNotebookModel, notebookId:string|undefined, content: { [key: string]: any }) {
     const cellMap = notebookId ? notebookCellMap.get(notebookId) : undefined;
     const cellsArray = Array.from(notebook.cells);
     cellsArray.forEach(cell => {
       if (cell.type === 'code') {
         const cId = truncateCellId(cell.id);
-        if (codeDict.hasOwnProperty(cId)) {
-          const updatedCode = codeDict[cId];
-          const dfmetadata = cell.getMetadata('dfmetadata');
-
-          if (cellMap) {
-            if (cellMap?.get(cId) !== cell.sharedModel.getSource()) {
-              cell.sharedModel.setSource(updatedCode);
-              cellMap.set(cId, updatedCode.trim());
-            } else {
-              cellMap.set(cId, updatedCode.trim());
-              cell.sharedModel.setSource(updatedCode);
-            }
+        const cAny = cell as ICodeCellModel;
+        
+        if (content.code_dict.hasOwnProperty(cId)) {
+          //updating last executed code of cell in cellMap first to maintain dfcell dirty state
+          if (content.executed_code_dict?.hasOwnProperty(cId) && cellMap) {
+            const updatedCode = content.executed_code_dict[cId];
+            cellMap?.set(cId, updatedCode.trim());
           }
-          cell.setMetadata('dfmetadata', dfmetadata);
+          
+          const updatedCode = content.code_dict[cId];
+          cAny.sharedModel.setSource(updatedCode);
         }
       }
     });
@@ -338,7 +344,7 @@ import { truncateCellId } from '@dfnotebook/dfutils';
         const c = cell as ICodeCellModel;
         const cId = truncateCellId(c.id);
         const dfmetadata = c.getMetadata('dfmetadata');
-        if(!dfmetadata.persistentCode)
+        if(!dfmetadata.persistentCode && cId != cellUUID)
         {
           cellIdModelMap[cId] = c;
           return;

--- a/frontend/packages/dfnotebook/src/cellexecutor.ts
+++ b/frontend/packages/dfnotebook/src/cellexecutor.ts
@@ -12,6 +12,7 @@ import { KernelError, INotebookModel, INotebookCellExecutor } from '@jupyterlab/
 import { DataflowCodeCell } from '@dfnotebook/dfcells';
 import { DataflowNotebookModel } from './model';
 import { notebookCellMap, getNotebookId } from '@dfnotebook/dfcells';
+import { Manager as GraphManager } from '@dfnotebook/dfgraph';
 import { truncateCellId } from '@dfnotebook/dfutils';
 
 /**
@@ -110,7 +111,11 @@ import { truncateCellId } from '@dfnotebook/dfutils';
               }
 
               if (sessionContext?.session?.kernel) {
-                await dfCommPostData(notebookId, notebook as DataflowNotebookModel, sessionContext)
+                await dfCommPostData(notebookId, notebook as DataflowNotebookModel, sessionContext);
+                
+                let sessId = sessionContext.session.id;
+                let dfData = getCellsMetadata(notebook, cellUUID);
+                GraphManager.graphs[sessId].updateCellContents(dfData.dfMetadata.code_dict);
               }
             } 
             else {

--- a/frontend/packages/dfnotebook/test/cellexecutor.spec.ts
+++ b/frontend/packages/dfnotebook/test/cellexecutor.spec.ts
@@ -1,0 +1,750 @@
+import { SessionContext, ISessionContext } from '@jupyterlab/apputils';
+import { createSessionContext } from '@jupyterlab/apputils/lib/testutils';
+import { JupyterServer } from '@jupyterlab/testing';
+import { DataflowNotebookModel } from '../src';
+import * as utils from './utils';
+import { Context } from '@jupyterlab/docregistry';
+import { INotebookModel, NotebookActions, NotebookPanel } from '@jupyterlab/notebook';
+import * as nbformat from '@jupyterlab/nbformat';
+import { CodeCell, ICodeCellModel } from '@jupyterlab/cells';
+import { truncateCellId } from '@dfnotebook/dfutils';
+import { updateNotebookCellsWithTag }  from '../../dfnotebook-extension/src/index';
+
+const server = new JupyterServer();
+
+beforeAll(async () => {
+  await server.start({'additionalKernelSpecs':{'dfpython3':{'argv':['python','-m','dfnotebook.kernel','-f','{connection_file}'],'display_name':'DFPython 3','language':'python'}}});
+}, 30000);
+
+afterAll(async () => {
+  await server.shutdown();
+});
+
+describe('@dfnotebook/cellExecutor', () => {
+  let sessionContext: ISessionContext;
+  let context: Context<INotebookModel>;
+  let panel: NotebookPanel;
+  
+  beforeAll(async function () {
+    sessionContext = await createSessionContext(
+      {'kernelPreference':
+      {'name':'dfpython3','autoStartDefault':true,'shouldStart':true}});
+  
+    await (sessionContext as SessionContext).initialize();
+    await sessionContext.session?.kernel?.info;
+    await sessionContext.session?.id;
+    await sessionContext.startKernel();
+  }, 30000);
+
+      
+  beforeEach(async () => {
+    let notebookContent: nbformat.INotebookContent = {
+      metadata: {
+        kernelspec: {
+          name: 'dfpython3',
+          display_name: 'DFPython 3'
+        },
+      },
+      cells: [],
+      nbformat: 4,
+      nbformat_minor: 5,
+    };
+    
+    context = await utils.createMockContext(true);
+    context.model.fromJSON(notebookContent);
+    
+    panel = utils.createNotebookPanel(context);
+    panel.id = 'mock-notebook-panel';
+    panel.content.model = context.model as DataflowNotebookModel;
+    
+  });
+
+  afterEach(() => {
+    panel?.dispose();
+    utils.clipboard.clear();
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      sessionContext.shutdown()
+    ]);
+  });
+
+  describe('uuid reference', () => {
+    it('uuid not added for identifier if exported once', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);  // true when execution succeeds
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+      
+      // verifies no ref UUID is added for identifier 'a' since it is exported only once
+      const cell =  panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(cell.outputs.length).toBe(1);
+      expect(cell.outputs.get(0).data['text/plain']).toBe('18');
+      expect(cell.sharedModel.source).toBe('b=a+9');
+    });
+  
+    it('uuid for identifier is retained in case of ambiguity', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      const firstCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      const refId = truncateCellId(firstCell.id);
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);  // true when execution succeeds
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'a=5\ntest=a+99\nb=a$'+refId+'+99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // verifies UUID is retained in case of ambiguity
+      const lastExecutedCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(lastExecutedCell.sharedModel.getSource()).toBe('a=5\ntest=a+99\nb=a$'+refId+'+99');
+    });
+  
+    it('uuid for identifier is retained if exported more than once', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);  // true when execution succeeds
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // code cell 3
+      panel.content.model?.sharedModel.insertCell(2, {
+        cell_type: 'code',
+        source: 'a=99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[2]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // verifies UUID is added for identifier 'a' since it is exported twice
+      const firstCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      const refId = truncateCellId(firstCell.id);
+      const secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a$'+refId+'+9');
+    });
+  
+    it('uuid removed if identifier exported once (case delete cell)', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);  // true when execution succeeds
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // code cell 3
+      panel.content.model?.sharedModel.insertCell(2, {
+        cell_type: 'code',
+        source: 'a=99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[2]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // verifies UUID is added for identifier 'a' since it is exported twice
+      const firstCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      const refId = truncateCellId(firstCell.id);
+      let secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a$'+refId+'+9');
+  
+      //deleting code cell 3
+      panel.content.model?.sharedModel.deleteCell(2)
+  
+      panel.content.select(panel.content.widgets[0]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a+9');
+    });
+
+    it('uuid removed if identifier exported once (case change in code)', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);  // true when execution succeeds
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // code cell 3
+      panel.content.model?.sharedModel.insertCell(2, {
+        cell_type: 'code',
+        source: 'a=99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[2]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // verifies UUID is added for identifier 'a' since it is exported twice
+      const firstCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      const refId = truncateCellId(firstCell.id);
+      let secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a$'+refId+'+9');
+  
+      //updating code cell 3
+      panel.content.select(panel.content.widgets[2]);
+      const thirdCell = panel.content.model?.cells.get(2) as ICodeCellModel;
+      thirdCell.sharedModel.setSource('');
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      panel.content.select(panel.content.widgets[0]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a+9');
+    });
+  
+    it('uuid is added to identifers when exported variable is deleted', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);  // true when execution succeeds
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      let secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a+9');
+  
+      const firstCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      const refId = truncateCellId(firstCell.id);
+      
+      //deleting code code cell 1
+      panel.content.model?.sharedModel.deleteCell(0)
+  
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+      
+      // verifies UUID is added when identifier is deleted or removed
+      let cell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      expect(cell.sharedModel.getSource()).toBe('b=a$'+refId+'+9');
+    });
+  });
+
+  describe('tag reference', () => {
+    it('tag can be used as reference', async () =>{
+       // code cell 1
+       panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);  // true when execution succeeds
+
+      //add tag
+      panel.content.select(panel.content.widgets[0]);
+      let firstCell = panel.content.widgets[0] as CodeCell;
+      (firstCell.inputArea as any).addTag?.("testTag");
+      
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'a=5\ntest=a+99\nb=a$testTag+99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // verifies UUID is retained in case of ambiguity
+      const lastExecutedCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(lastExecutedCell.outputs.length).toBe(1);
+      expect(lastExecutedCell.outputs.get(0).data['text/plain']).toBe('108');
+      expect(lastExecutedCell.sharedModel.getSource()).toBe('a=5\ntest=a+99\nb=a$testTag+99');
+    });
+
+    it('adding tag should update references', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);  // true when execution succeeds
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // code cell 3
+      panel.content.model?.sharedModel.insertCell(2, {
+        cell_type: 'code',
+        source: 'c=a+99\nb=a+c\na="xyz"\na',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[2]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // verifies UUID is added for identifier 'a' since it is exported twice
+      let firstCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      const refId = truncateCellId(firstCell.id);
+
+      let secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a$'+refId+'+9');
+
+      let thirdCell = panel.content.model?.cells.get(2) as ICodeCellModel;
+      expect(thirdCell.sharedModel.getSource()).toBe('c=a$'+refId+'+99\nb=a$'+refId+'+c\na=\"xyz\"\na');
+
+      //add tag
+      panel.content.select(panel.content.widgets[0]);
+      let cell = panel.content.widgets[0] as CodeCell;
+      (cell.inputArea as any).addTag?.("testTag");
+      await updateNotebookCellsWithTag(panel.content.model as DataflowNotebookModel, refId, sessionContext);
+      
+      // verifies tag is added for identifier references of 'a'
+      secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a$testTag+9');
+
+      thirdCell = panel.content.model?.cells.get(2) as ICodeCellModel;
+      expect(thirdCell.sharedModel.getSource()).toBe('c=a$testTag+99\nb=a$testTag+c\na=\"xyz\"\na');
+    });
+
+    it('deleting tag should should update references with uuid', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+
+      //add tag
+      panel.content.select(panel.content.widgets[0]);
+      let firstCell = panel.content.widgets[0] as CodeCell;
+      const refId = truncateCellId(firstCell.model.sharedModel.id);
+      (firstCell.inputArea as any).addTag?.("testTag");
+
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+      
+      // code cell 3
+      panel.content.model?.sharedModel.insertCell(2, {
+        cell_type: 'code',
+        source: 'c=a+99\nb=a+c\na="xyz"\na',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[2]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+
+      // verify tag is used inplace of uuid
+      let secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a$testTag+9');
+  
+      let thirdCell = panel.content.model?.cells.get(2) as ICodeCellModel;
+      expect(thirdCell.sharedModel.getSource()).toBe('c=a$testTag+99\nb=a$testTag+c\na=\"xyz\"\na');
+      
+      //delete tag
+      panel.content.select(panel.content.widgets[0]);
+      firstCell = panel.content.widgets[0] as CodeCell;
+      (firstCell.inputArea as any).addTag?.("");
+
+      await updateNotebookCellsWithTag(panel.content.model as DataflowNotebookModel, refId, sessionContext);
+
+      // verifies UUID is added when tag is deleted
+      secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      expect(secondCell.sharedModel.getSource()).toBe('b=a$'+refId+'+9');
+
+      thirdCell = panel.content.model?.cells.get(2) as ICodeCellModel;
+      expect(thirdCell.sharedModel.getSource()).toBe('c=a$'+refId+'+99\nb=a$'+refId+'+c\na=\"xyz\"\na');
+    });
+
+    it('deleting cell with tag should update references with uuid', async () =>{
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+       cell_type: 'code',
+       source: 'a=9',
+       metadata: {
+         trusted: false
+       }
+     });
+     
+     //make cell active and execute
+     panel.content.select(panel.content.widgets[0]);
+     let result = await NotebookActions.run(panel.content, sessionContext);
+     expect(result).toBe(true);
+
+     //add tag
+     panel.content.select(panel.content.widgets[0]);
+     const firstCell = panel.content.widgets[0] as CodeCell;
+     const refId = truncateCellId(firstCell.model.sharedModel.id);
+     (firstCell.inputArea as any).addTag?.("testTag");
+     
+     // code cell 2
+     panel.content.model?.sharedModel.insertCell(1, {
+       cell_type: 'code',
+       source: 'a=5\ntest=a+99\nb=a$testTag+99',
+       metadata: {
+         trusted: false
+       }
+     });
+ 
+     //make cell active and execute
+     panel.content.select(panel.content.widgets[1]);
+     result = await NotebookActions.run(panel.content, sessionContext);
+     expect(result).toBe(true);
+
+     //deleting code cell 1 and running a cell
+     panel.content.model?.sharedModel.deleteCellRange(0,1)
+     panel.content.select(panel.content.widgets[1]);
+     result = await NotebookActions.run(panel.content, sessionContext);
+     expect(result).toBe(true);
+ 
+     // verifies tagvalue is replced with uuid
+     const lastExecutedCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+     expect(lastExecutedCell.sharedModel.getSource()).toBe('a=5\ntest=a+99\nb=a$'+refId+'+99');
+    }); 
+   });
+
+  describe('dfmetdata', () => {
+    it('dfcode cell should contain dfmetadata inside metadata', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+
+      let expectedDFMetadata = {
+              "inputVars": {
+               "ref": {},
+               "tag_refs": {}
+              },
+              "outputVars": [],
+              "persistentCode": "",
+              "tag": ""
+            }
+
+      let cell = panel.content.model?.cells.get(0) as ICodeCellModel;;
+      let dfmetadata = cell.sharedModel.getMetadata('dfmetadata')
+      expect(dfmetadata).toBeDefined();
+      expect(dfmetadata).toEqual(expectedDFMetadata);
+    });
+  
+    it('inputVars and outputVars should be updated on sucessful execution', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      const firstCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      const firstCellId = truncateCellId(firstCell.id);
+  
+      const secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      let dfmetadata = secondCell.getMetadata("dfmetadata")
+      
+      // verifies references in cell 2 dfmetadata
+      expect(dfmetadata).toBeDefined();
+        expect(dfmetadata.inputVars).toEqual({
+          "ref": {
+            [firstCellId]: ["a"]
+          },
+          "tag_refs": {}
+        });
+      expect(dfmetadata.outputVars).toEqual(['b'])
+    });
+
+    it('persistentCode should be updated with executed code having references', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[0]);
+      let result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      // code cell 2
+      panel.content.model?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      //make cell active and execute
+      panel.content.select(panel.content.widgets[1]);
+      result = await NotebookActions.run(panel.content, sessionContext);
+      expect(result).toBe(true);
+  
+      const firstCell = panel.content.model?.cells.get(0) as ICodeCellModel;
+      const firstCellId = truncateCellId(firstCell.id);
+  
+      const secondCell = panel.content.model?.cells.get(1) as ICodeCellModel;
+      let dfmetadata = secondCell.getMetadata("dfmetadata")
+      
+      expect(dfmetadata).toBeDefined();
+      expect(secondCell.sharedModel.getSource()).toEqual('b=a+9');
+      expect(dfmetadata.persistentCode).toEqual('b=a$'+firstCellId+'+9');
+    });
+  
+    it('tag value should be updated in dfmetadata when cell is tagged', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      //const inputArea = (panel.content.widgets[0] as CodeCell).inputArea as any;
+      
+      let cell = panel.content.widgets[0] as CodeCell;
+      (cell.inputArea as any).addTag?.("testTag");
+      let dfmetadata = cell.model.getMetadata('dfmetadata');
+      expect(dfmetadata).toBeDefined();
+      expect(dfmetadata.tag).toEqual('testTag');
+    });
+
+    it('tag value should be updated when tag is deleted', async () => {
+      // code cell 1
+      panel.content.model?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+      
+      let cell = panel.content.widgets[0] as CodeCell;
+      (cell.inputArea as any).addTag?.("testTag");
+      let dfmetadata = cell.model.getMetadata('dfmetadata');
+      expect(dfmetadata).toBeDefined();
+      expect(dfmetadata.tag).toEqual('testTag');
+
+      (cell.inputArea as any).addTag?.("");
+      dfmetadata = cell.model.getMetadata('dfmetadata');
+      expect(dfmetadata).toBeDefined();
+      expect(dfmetadata.tag).toEqual('');
+    });
+  });
+});

--- a/frontend/packages/dfoutputarea/test/widget.spec.ts
+++ b/frontend/packages/dfoutputarea/test/widget.spec.ts
@@ -69,7 +69,7 @@ describe('outputarea/widget', () => {
       values: DEFAULT_OUTPUTS,
       trusted: true
     });
-    widget = new LogOutputArea({ rendermime, model }, 'cellId');
+    widget = new LogOutputArea({ rendermime, model }, '000aaa');
   });
 
   afterEach(() => {
@@ -350,7 +350,7 @@ describe('outputarea/widget', () => {
         mockdata['uuid'] = uuid;
         mockdata['code_dict'] = code_dict;
         mockmap[uuid] = widget;
-        const reply = await OutputArea.execute(CODE, widget, sessionContext,metadata,mockdata,mockmap);
+        const reply = await OutputArea.execute(CODE, widget, sessionContext,metadata,mockdata,mockmap,uuid);
         expect(reply!.content.execution_count).toBeTruthy();
         expect(reply!.content.status).toBe('ok');
         
@@ -369,18 +369,18 @@ describe('outputarea/widget', () => {
         mockdata['uuid'] = uuid;
         mockdata['code_dict'] = code_dict;
         mockmap[uuid] = widget;
-        const reply = await OutputArea.execute(CODE, widget, sessionContext,metadata,mockdata,mockmap);
+        const reply = await OutputArea.execute(CODE, widget, sessionContext,metadata,mockdata,mockmap,uuid);
         expect(reply!.content.execution_count).toBeTruthy();
         expect(model.length).toBe(0);
       });
 
       it('should handle routing of display messages', async () => {
         const model0 = new OutputAreaModel({ trusted: true });
-        const widget0 = new LogOutputArea({ rendermime, model: model0 }, 'aaaaaaaa');
+        const widget0 = new LogOutputArea({ rendermime, model: model0 }, 'aaaaaaa1');
         const model1 = new OutputAreaModel({ trusted: true });
-        const widget1 = new LogOutputArea({ rendermime, model: model1 }, 'bbbbbbbb');
+        const widget1 = new LogOutputArea({ rendermime, model: model1 }, 'bbbbbbb1');
         const model2 = new OutputAreaModel({ trusted: true });
-        const widget2 = new LogOutputArea({ rendermime, model: model2 }, 'cccccccc');
+        const widget2 = new LogOutputArea({ rendermime, model: model2 }, 'ccccccc1');
 
         const code0 = [
           'ip = get_ipython()',
@@ -413,16 +413,16 @@ describe('outputarea/widget', () => {
         code_dict[uuid] = code0;
         mockdata['uuid'] = uuid;
         mockdata['code_dict'] = code_dict;
-        mockmap[uuid] = widget;
+        mockmap[uuid] = widget0;
 
-        const promise0 = OutputArea.execute(code0, widget0, ipySessionContext,{},mockdata,mockmap);
+        const promise0 = OutputArea.execute(code0, widget0, ipySessionContext,{},mockdata,mockmap,uuid);
         uuid = String(widget1.cellId);
         mockdata['uuid'] = uuid;
         code_dict[uuid] = code1;
         mockdata['code_dict'] = code_dict;
         metadata['cellId'] = uuid;
         mockmap[uuid] = widget1;
-        const promise1 = OutputArea.execute(code1, widget1, ipySessionContext,{},mockdata,mockmap);
+        const promise1 = OutputArea.execute(code1, widget1, ipySessionContext,{},mockdata,mockmap,uuid);
         await Promise.all([promise0, promise1]);
         expect(model1.length).toBe(1);
         const outputs2 = model1.toJSON();
@@ -434,7 +434,7 @@ describe('outputarea/widget', () => {
         mockdata['code_dict'] = code_dict;
         metadata['cellId'] = uuid;
         mockmap[uuid] = widget2;
-        await OutputArea.execute(code2, widget2, ipySessionContext,metadata,mockdata,mockmap);
+        await OutputArea.execute(code2, widget2, ipySessionContext,metadata,mockdata,mockmap,uuid);
         
         expect(model1.length).toBe(1);
         expect(model2.length).toBe(3);
@@ -454,7 +454,7 @@ describe('outputarea/widget', () => {
           {'kernelPreference':
           {'name':'dfpython3','autoStartDefault':true,'shouldStart':true}});
         await ipySessionContext.initialize();
-        const widget1 = new LogOutputArea({ rendermime, model }, 'cellId');
+        const widget1 = new LogOutputArea({ rendermime, model }, 'aaaaaaa1');
         let uuid = widget1.cellId;
         let metadata: any = {};
         let code_dict: any = {};
@@ -465,13 +465,13 @@ describe('outputarea/widget', () => {
         mockdata['uuid'] = uuid;
         mockdata['code_dict'] = code_dict;
         mockmap[uuid] = widget;
-        const future1 = OutputArea.execute('a++1', widget, ipySessionContext,metadata,mockdata,mockmap);
+        const future1 = OutputArea.execute('a++1', widget, ipySessionContext,metadata,mockdata,mockmap,uuid);
         uuid = String(widget1.cellId);
         mockdata['uuid'] = uuid;
         code_dict[uuid] = 'a=1';
         mockdata['code_dict'] = code_dict;
         metadata['cellId'] = uuid;
-        const future2 = OutputArea.execute('a=1', widget1, ipySessionContext,metadata,mockdata,mockmap);
+        const future2 = OutputArea.execute('a=1', widget1, ipySessionContext,metadata,mockdata,mockmap,uuid);
         const reply = await future1;
         const reply2 = await future2;
         expect(reply!.content.status).toBe('error');
@@ -487,7 +487,7 @@ describe('outputarea/widget', () => {
           {'kernelPreference':
           {'name':'dfpython3','autoStartDefault':true,'shouldStart':true}});
         await ipySessionContext.initialize();
-        const widget1 = new LogOutputArea({ rendermime, model }, 'cellId');
+        const widget1 = new LogOutputArea({ rendermime, model }, 'aaaaaaa1');
         let uuid = widget1.cellId;
         let metadata: any = {};
         let code_dict: any = {};
@@ -504,14 +504,15 @@ describe('outputarea/widget', () => {
           ipySessionContext,
           metadata,
           mockdata,
-          mockmap
+          mockmap,
+          uuid
         );
         uuid = String(widget1.cellId);
         mockdata['uuid'] = uuid;
         code_dict[uuid] = 'a=1';
         mockdata['code_dict'] = code_dict;
         metadata['cellId'] = uuid;
-        const future2 = OutputArea.execute('a=1', widget1, ipySessionContext,metadata,mockdata,mockmap);
+        const future2 = OutputArea.execute('a=1', widget1, ipySessionContext,metadata,mockdata,mockmap,uuid);
         const reply = await future1;
         const reply2 = await future2;
         expect(reply!.content.status).toBe('error');


### PR DESCRIPTION
This PR builds upon the changes introduced in [PR 132](https://github.com/dataflownb/dfnotebook/pull/132). It includes tests related to:
- **UUID references in cells**
- **Tag references in cells**
- **Dfmetadata**

_**Note**: PR 132 must be merged before this PR to ensure all tests run successfully._
